### PR TITLE
copomser: minimal PHP version changed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": "~7.1.0",
+    "php": "~7.1.0|~7.4.0|~8.0|~8.1",
     "magento/module-config": "*"
   },
   "type": "magento2-module",


### PR DESCRIPTION
We've added another PHP versions so it can be used with latest Magento 2 release